### PR TITLE
Fix bug with output interval

### DIFF
--- a/src/main.hpp
+++ b/src/main.hpp
@@ -282,7 +282,6 @@ const std::string run(std::string& json_config) {
       interval_counter = 0;
     }
   }
-  std::cout << states.size() << std::endl;
 
   // Make times start from 0
   if (reader.output_last_cycle_only) {


### PR DESCRIPTION
Extracting the last cardiac cycle didn't consider the output interval, resulting in keeping more than the last cardiac cycle when output_interval is larger than 1. This led to a `double free or corruption (!prev)` error when the output interval number was higher than number of cardiac cycles.

This PR also optimizes memory reservation of the states and times array if only the last cardiac cycle is needed and/or the output interval is larger than 1.