### PR TITLE
Fix OpenLoopCoronary equations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ Release*/
 Debug*/
 externals/
 *.so
-build
+build*/
 
 # IDE
 .cproject

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ add_executable(svzerodsolver applications/svzerodsolver.cpp
 )
 
 add_executable(svzerodcalibrator applications/svzerodcalibrator.cpp
+  $<TARGET_OBJECTS:svzero_algebra_library> 
   $<TARGET_OBJECTS:svzero_optimize_library> 
   $<TARGET_OBJECTS:svzero_model_library> 
 )

--- a/applications/svzerodsolver.cpp
+++ b/applications/svzerodsolver.cpp
@@ -61,6 +61,7 @@ int main(int argc, char* argv[]) {
   }
 
   std::string input_file_name = argv[1];
+  std::string output_file_path;
   std::string output_file_name;
 
   if (argc == 3) {
@@ -74,11 +75,15 @@ int main(int argc, char* argv[]) {
       end_of_path = input_file_name.rfind("\\");  // For Windows paths (?)
 
       if (end_of_path == std::string::npos) {
-        throw std::runtime_error("Error: No output file path provided. Tried to create a default output file but could not find the simulation directory from the input JSON file path.");
+        output_file_path = ".";
+        //throw std::runtime_error("Error: No output file path provided. Tried to create a default output file but could not find the simulation directory from the input JSON file path.");
       }
+    } else {
+      output_file_path = input_file_name.substr(0, end_of_path);
     }
 
-    output_file_name = input_file_name.substr(0, end_of_path) + "/output.csv";
+    //output_file_name = input_file_name.substr(0, end_of_path) + "/output.csv";
+    output_file_name = output_file_path + "/output.csv";
     std::cout << "[svzerodsolver] Output will be written to '" << output_file_name << "'." << std::endl;;
   }
 

--- a/applications/svzerodsolver.cpp
+++ b/applications/svzerodsolver.cpp
@@ -74,15 +74,14 @@ int main(int argc, char* argv[]) {
     if (end_of_path == std::string::npos) {
       end_of_path = input_file_name.rfind("\\");  // For Windows paths (?)
 
+      // If <path to .json> is still not found, use current directory
       if (end_of_path == std::string::npos) {
         output_file_path = ".";
-        //throw std::runtime_error("Error: No output file path provided. Tried to create a default output file but could not find the simulation directory from the input JSON file path.");
       }
     } else {
       output_file_path = input_file_name.substr(0, end_of_path);
     }
 
-    //output_file_name = input_file_name.substr(0, end_of_path) + "/output.csv";
     output_file_name = output_file_path + "/output.csv";
     std::cout << "[svzerodsolver] Output will be written to '" << output_file_name << "'." << std::endl;;
   }

--- a/src/model/Block.cpp
+++ b/src/model/Block.cpp
@@ -72,6 +72,8 @@ void Block::setup_dofs(DOFHandler &dofhandler) {}
 
 void Block::setup_model_dependent_params() {}
 
+void Block::setup_initial_state_dependent_params(State initial_state) {}
+
 void Block::update_constant(SparseSystem &system,
                             std::vector<double> &parameters) {}
 

--- a/src/model/Block.cpp
+++ b/src/model/Block.cpp
@@ -72,7 +72,7 @@ void Block::setup_dofs(DOFHandler &dofhandler) {}
 
 void Block::setup_model_dependent_params() {}
 
-void Block::setup_initial_state_dependent_params(State initial_state) {}
+void Block::setup_initial_state_dependent_params(State initial_state, std::vector<double> &parameters) {}
 
 void Block::update_constant(SparseSystem &system,
                             std::vector<double> &parameters) {}

--- a/src/model/Block.cpp
+++ b/src/model/Block.cpp
@@ -72,7 +72,8 @@ void Block::setup_dofs(DOFHandler &dofhandler) {}
 
 void Block::setup_model_dependent_params() {}
 
-void Block::setup_initial_state_dependent_params(State initial_state, std::vector<double> &parameters) {}
+void Block::setup_initial_state_dependent_params(
+    State initial_state, std::vector<double> &parameters) {}
 
 void Block::update_constant(SparseSystem &system,
                             std::vector<double> &parameters) {}

--- a/src/model/Block.h
+++ b/src/model/Block.h
@@ -232,8 +232,9 @@ class Block {
    * @brief Setup parameters that depend on the initial state
    *
    * @param initial_state The initial state of the system
+   * @param parameters The parameter values vector (at time 0)
    */
-  virtual void setup_initial_state_dependent_params(State initial_state);
+  virtual void setup_initial_state_dependent_params(State initial_state, std::vector<double> &parameters);
 
   /**
    * @brief Update the constant contributions of the element in a sparse system

--- a/src/model/Block.h
+++ b/src/model/Block.h
@@ -43,6 +43,7 @@
 #include "DOFHandler.h"
 #include "Parameter.h"
 #include "SparseSystem.h"
+#include "State.h"
 
 /**
  * @brief The number of triplets that the element contributes
@@ -226,6 +227,13 @@ class Block {
    *
    */
   virtual void setup_model_dependent_params();
+
+  /**
+   * @brief Setup parameters that depend on the initial state
+   *
+   * @param initial_state The initial state of the system
+   */
+  virtual void setup_initial_state_dependent_params(State initial_state);
 
   /**
    * @brief Update the constant contributions of the element in a sparse system

--- a/src/model/Block.h
+++ b/src/model/Block.h
@@ -234,7 +234,8 @@ class Block {
    * @param initial_state The initial state of the system
    * @param parameters The parameter values vector (at time 0)
    */
-  virtual void setup_initial_state_dependent_params(State initial_state, std::vector<double> &parameters);
+  virtual void setup_initial_state_dependent_params(
+      State initial_state, std::vector<double> &parameters);
 
   /**
    * @brief Update the constant contributions of the element in a sparse system

--- a/src/model/Model.cpp
+++ b/src/model/Model.cpp
@@ -287,6 +287,14 @@ TripletsContributions Model::get_num_triplets() const {
   }
 
   return triplets_sum;
+
+}
+
+void Model::setup_initial_state_dependent_parameters(State initial_state) {
+  DEBUG_MSG("Setup initial state dependent parameters");
+  for (auto &block : blocks) {
+    block->setup_initial_state_dependent_params(initial_state);
+  }
 }
 
 void Model::update_has_windkessel_bc(bool has_windkessel) {

--- a/src/model/Model.cpp
+++ b/src/model/Model.cpp
@@ -254,6 +254,7 @@ void Model::to_steady() {
     param.to_steady();
   }
 
+  // Special handling for time-varying capacitance
   for (size_t i = 0; i < get_num_blocks(true); i++) {
     get_block(i)->steady = true;
     if ((block_types[i] == BlockType::windkessel_bc) ||

--- a/src/model/Model.cpp
+++ b/src/model/Model.cpp
@@ -293,7 +293,7 @@ TripletsContributions Model::get_num_triplets() const {
 void Model::setup_initial_state_dependent_parameters(State initial_state) {
   DEBUG_MSG("Setup initial state dependent parameters");
   for (auto &block : blocks) {
-    block->setup_initial_state_dependent_params(initial_state);
+    block->setup_initial_state_dependent_params(initial_state, parameter_values);
   }
 }
 

--- a/src/model/Model.cpp
+++ b/src/model/Model.cpp
@@ -288,13 +288,13 @@ TripletsContributions Model::get_num_triplets() const {
   }
 
   return triplets_sum;
-
 }
 
 void Model::setup_initial_state_dependent_parameters(State initial_state) {
   DEBUG_MSG("Setup initial state dependent parameters");
   for (auto &block : blocks) {
-    block->setup_initial_state_dependent_params(initial_state, parameter_values);
+    block->setup_initial_state_dependent_params(initial_state,
+                                                parameter_values);
   }
 }
 

--- a/src/model/Model.h
+++ b/src/model/Model.h
@@ -338,7 +338,7 @@ class Model {
   /**
    * @brief Setup model parameters that depend on the initial state
    *
-   * @param initial_state The initial state
+   * @param initial_state The initial state vector
    */
   void setup_initial_state_dependent_parameters(State initial_state);
 

--- a/src/model/Model.h
+++ b/src/model/Model.h
@@ -60,10 +60,10 @@
 #include "PressureReferenceBC.h"
 #include "ResistanceBC.h"
 #include "ResistiveJunction.h"
+#include "State.h"
 #include "ValveTanh.h"
 #include "WindkesselBC.h"
 #include "debug.h"
-#include "State.h"
 
 /**
  * @brief Model of 0D elements

--- a/src/model/Model.h
+++ b/src/model/Model.h
@@ -63,6 +63,7 @@
 #include "ValveTanh.h"
 #include "WindkesselBC.h"
 #include "debug.h"
+#include "State.h"
 
 /**
  * @brief Model of 0D elements
@@ -334,6 +335,12 @@ class Model {
    * @return double Largest Windkessel time constant of model
    */
   double get_largest_windkessel_time_constant();
+  /**
+   * @brief Setup model parameters that depend on the initial state
+   *
+   * @param initial_state The initial state
+   */
+  void setup_initial_state_dependent_parameters(State initial_state);
 
  private:
   int block_count = 0;

--- a/src/model/OpenLoopCoronaryBC.cpp
+++ b/src/model/OpenLoopCoronaryBC.cpp
@@ -74,12 +74,15 @@ void OpenLoopCoronaryBC::update_time(SparseSystem &system,
   auto Pv = parameters[global_param_ids[6]];
 
   if (steady) {
-    system.C(global_eqn_ids[0]) = -Cim * Pim;
+    std::cout<<this->P_Cim_0 << " " <<this->Pim_0<<std::endl;
+    //system.C(global_eqn_ids[0]) = -Cim * Pim;
+    system.C(global_eqn_ids[0]) = Cim * (Pim - this->Pim_0 + this->P_Cim_0);
     system.C(global_eqn_ids[1]) = Pv;
   } else {
+    std::cout<<this->P_Cim_0 << " " <<this->Pim_0<<std::endl;
     //system.C(global_eqn_ids[0]) = Cim * (-Pim + Pv);
     system.C(global_eqn_ids[0]) = Cim * (-Pim + Pv + this->Pim_0 - this->P_Cim_0);
-    system.C(global_eqn_ids[1]) = -Cim * (Rv + Ram) * Pim + (Ram * Cim * Pv) - (Cim * (Rv + Ram) * (this->P_Cim_0 - this->Pim_0));
+    system.C(global_eqn_ids[1]) = (Ram * Cim * Pv) - Cim * (Rv + Ram) * (Pim + this->P_Cim_0 - this->Pim_0);
   }
 }
 
@@ -99,7 +102,7 @@ void OpenLoopCoronaryBC::setup_initial_state_dependent_params(State initial_stat
   auto P_Ca = P_in - Ra*Q_in;
   auto P_Ca_dot = P_in_dot - Ra*Q_in_dot; 
   auto Q_am = Q_in - Ca*P_Ca_dot;
-  P_Cim_0 = P_Ca - Ram*Q_am;
+  this->P_Cim_0 = P_Ca - Ram*Q_am;
   //P_Cim_0 = Pv + Rv*Q_out;
-  Pim_0 = parameters[global_param_ids[5]];
+  this->Pim_0 = parameters[global_param_ids[5]];
 }

--- a/src/model/OpenLoopCoronaryBC.cpp
+++ b/src/model/OpenLoopCoronaryBC.cpp
@@ -45,8 +45,8 @@ void OpenLoopCoronaryBC::update_constant(SparseSystem &system,
   if (steady) {
     // Different assmembly for steady block to avoid singular system
     // and solve for the internal variable V_im inherently
-    system.F.coeffRef(global_eqn_ids[0], global_var_ids[0]) = -Cim;
-    system.F.coeffRef(global_eqn_ids[0], global_var_ids[1]) = Cim * (Ra + Ram);
+//  system.F.coeffRef(global_eqn_ids[0], global_var_ids[0]) = -Cim;
+//  system.F.coeffRef(global_eqn_ids[0], global_var_ids[1]) = Cim * (Ra + Ram);
     system.F.coeffRef(global_eqn_ids[0], global_var_ids[2]) = 1.0;
     system.F.coeffRef(global_eqn_ids[1], global_var_ids[0]) = -1.0;
     system.F.coeffRef(global_eqn_ids[1], global_var_ids[1]) = Ra + Ram + Rv;
@@ -76,7 +76,7 @@ void OpenLoopCoronaryBC::update_time(SparseSystem &system,
   if (steady) {
     std::cout<<this->P_Cim_0 << " " <<this->Pim_0<<std::endl;
     //system.C(global_eqn_ids[0]) = -Cim * Pim;
-    system.C(global_eqn_ids[0]) = Cim * (Pim - this->Pim_0 + this->P_Cim_0);
+//  system.C(global_eqn_ids[0]) = Cim * (Pim - this->Pim_0 + this->P_Cim_0);
     system.C(global_eqn_ids[1]) = Pv;
   } else {
     std::cout<<this->P_Cim_0 << " " <<this->Pim_0<<std::endl;
@@ -87,22 +87,28 @@ void OpenLoopCoronaryBC::update_time(SparseSystem &system,
 }
 
 void OpenLoopCoronaryBC::setup_initial_state_dependent_params(State initial_state, std::vector<double> &parameters) {
-  //P_Cim_0 = 0.0;
-  //Pim_0 = 0.0;
-  //auto Rv = parameters[global_param_ids[2]];
-  //auto Pv = parameters[global_param_ids[6]];
-  //auto Q_im = initial_state.ydot[global_var_ids[2]];
-  auto P_in = initial_state.y[global_var_ids[0]];
-  auto Q_in = initial_state.y[global_var_ids[1]];
-  auto P_in_dot = initial_state.ydot[global_var_ids[0]];
-  auto Q_in_dot = initial_state.ydot[global_var_ids[1]];
-  auto Ra = parameters[global_param_ids[0]];
-  auto Ram = parameters[global_param_ids[1]];
-  auto Ca = parameters[global_param_ids[3]];
-  auto P_Ca = P_in - Ra*Q_in;
-  auto P_Ca_dot = P_in_dot - Ra*Q_in_dot; 
-  auto Q_am = Q_in - Ca*P_Ca_dot;
-  this->P_Cim_0 = P_Ca - Ram*Q_am;
-  //P_Cim_0 = Pv + Rv*Q_out;
-  this->Pim_0 = parameters[global_param_ids[5]];
+  if (steady) {
+//  this->P_Cim_0 = 220.0;
+//  this->Pim_0 = parameters[global_param_ids[5]];
+  } else {
+    //P_Cim_0 = 0.0;
+    //Pim_0 = 0.0;
+    //auto Rv = parameters[global_param_ids[2]];
+    //auto Pv = parameters[global_param_ids[6]];
+    //auto Q_im = initial_state.ydot[global_var_ids[2]];
+    //P_Cim_0 = Pv + Rv*Q_out;
+    auto P_in = initial_state.y[global_var_ids[0]];
+    auto Q_in = initial_state.y[global_var_ids[1]];
+    auto P_in_dot = initial_state.ydot[global_var_ids[0]];
+    auto Q_in_dot = initial_state.ydot[global_var_ids[1]];
+    auto Ra = parameters[global_param_ids[0]];
+    auto Ram = parameters[global_param_ids[1]];
+    auto Ca = parameters[global_param_ids[3]];
+    auto P_Ca = P_in - Ra*Q_in;
+    auto P_Ca_dot = P_in_dot - Ra*Q_in_dot; 
+    auto Q_am = Q_in - Ca*P_Ca_dot;
+    //std::cout << P_Ca << " " << P_Ca_dot << " " << Ram << " " << Q_am << std::endl;
+    this->P_Cim_0 = P_Ca - Ram*Q_am;
+    this->Pim_0 = parameters[global_param_ids[5]];
+  }
 }

--- a/src/model/OpenLoopCoronaryBC.cpp
+++ b/src/model/OpenLoopCoronaryBC.cpp
@@ -77,7 +77,13 @@ void OpenLoopCoronaryBC::update_time(SparseSystem &system,
     system.C(global_eqn_ids[0]) = -Cim * Pim;
     system.C(global_eqn_ids[1]) = Pv;
   } else {
-    system.C(global_eqn_ids[0]) = Cim * (-Pim + Pv);
-    system.C(global_eqn_ids[1]) = -Cim * (Rv + Ram) * Pim + Ram * Cim * Pv;
+    //system.C(global_eqn_ids[0]) = Cim * (-Pim + Pv);
+    system.C(global_eqn_ids[0]) = Cim * (-Pim + Pv + this->Pim_0 - this->P_Cim_0);
+    system.C(global_eqn_ids[1]) = -Cim * (Rv + Ram) * Pim + Ram * Cim * Pv -Cim * (Rv + Ram) * (this->P_Cim_0 - this->Pim_0);
   }
+}
+
+void OpenLoopCoronaryBC::setup_initial_state_dependent_params(State initial_state) {
+  P_Cim_0 = 0.0;
+  Pim_0 = 0.0;
 }

--- a/src/model/OpenLoopCoronaryBC.cpp
+++ b/src/model/OpenLoopCoronaryBC.cpp
@@ -43,10 +43,10 @@ void OpenLoopCoronaryBC::update_constant(SparseSystem &system,
   auto Cim = parameters[global_param_ids[4]];
 
   if (steady) {
-    // Different assmembly for steady block to avoid singular system
-    // and solve for the internal variable V_im inherently
-//  system.F.coeffRef(global_eqn_ids[0], global_var_ids[0]) = -Cim;
-//  system.F.coeffRef(global_eqn_ids[0], global_var_ids[1]) = Cim * (Ra + Ram);
+    // Different equations for steady initial condition
+    // Equations are:
+    // -P_in + (Ra+Ram+Rv)Q_in + Pv = 0
+    // V_im = 0
     system.F.coeffRef(global_eqn_ids[0], global_var_ids[2]) = 1.0;
     system.F.coeffRef(global_eqn_ids[1], global_var_ids[0]) = -1.0;
     system.F.coeffRef(global_eqn_ids[1], global_var_ids[1]) = Ra + Ram + Rv;
@@ -74,41 +74,28 @@ void OpenLoopCoronaryBC::update_time(SparseSystem &system,
   auto Pv = parameters[global_param_ids[6]];
 
   if (steady) {
-    //std::cout<<this->P_Cim_0 << " " <<this->Pim_0<<std::endl;
-    //system.C(global_eqn_ids[0]) = -Cim * Pim;
-//  system.C(global_eqn_ids[0]) = Cim * (Pim - this->Pim_0 + this->P_Cim_0);
     system.C(global_eqn_ids[1]) = Pv;
   } else {
-    //std::cout<<this->P_Cim_0 << " " <<this->Pim_0<<std::endl;
-    //system.C(global_eqn_ids[0]) = Cim * (-Pim + Pv);
     system.C(global_eqn_ids[0]) = Cim * (-Pim + Pv + this->Pim_0 - this->P_Cim_0);
     system.C(global_eqn_ids[1]) = (Ram * Cim * Pv) - Cim * (Rv + Ram) * (Pim + this->P_Cim_0 - this->Pim_0);
   }
 }
 
 void OpenLoopCoronaryBC::setup_initial_state_dependent_params(State initial_state, std::vector<double> &parameters) {
-//if (steady) {
-//  this->P_Cim_0 = 220.0;
-//  this->Pim_0 = parameters[global_param_ids[5]];
-//} else {
-    //P_Cim_0 = 0.0;
-    //Pim_0 = 0.0;
-    //auto Rv = parameters[global_param_ids[2]];
-    //auto Pv = parameters[global_param_ids[6]];
-    //auto Q_im = initial_state.ydot[global_var_ids[2]];
-    //P_Cim_0 = Pv + Rv*Q_out;
-    auto P_in = initial_state.y[global_var_ids[0]];
-    auto Q_in = initial_state.y[global_var_ids[1]];
-    auto P_in_dot = initial_state.ydot[global_var_ids[0]];
-    auto Q_in_dot = initial_state.ydot[global_var_ids[1]];
-    auto Ra = parameters[global_param_ids[0]];
-    auto Ram = parameters[global_param_ids[1]];
-    auto Ca = parameters[global_param_ids[3]];
-    auto P_Ca = P_in - Ra*Q_in;
-    auto P_Ca_dot = P_in_dot - Ra*Q_in_dot; 
-    auto Q_am = Q_in - Ca*P_Ca_dot;
-    //std::cout << P_Ca << " " << P_Ca_dot << " " << Ram << " " << Q_am << std::endl;
-    this->P_Cim_0 = P_Ca - Ram*Q_am;
-    this->Pim_0 = parameters[global_param_ids[5]];
-//}
+  auto P_in = initial_state.y[global_var_ids[0]];
+  auto Q_in = initial_state.y[global_var_ids[1]];
+  auto P_in_dot = initial_state.ydot[global_var_ids[0]];
+  auto Q_in_dot = initial_state.ydot[global_var_ids[1]];
+  auto Ra = parameters[global_param_ids[0]];
+  auto Ram = parameters[global_param_ids[1]];
+  auto Ca = parameters[global_param_ids[3]];
+  // Pressure proximal to Ca and distal to Ra
+  auto P_Ca = P_in - Ra*Q_in;
+  auto P_Ca_dot = P_in_dot - Ra*Q_in_dot;
+  // Flow into Ram (inflow minus flow into Ca)
+  auto Q_am = Q_in - Ca*P_Ca_dot;
+  // Pressure proximal to Cim/Vim and distal to Ram
+  this->P_Cim_0 = P_Ca - Ram*Q_am;
+  // Initial intramyocardial pressure
+  this->Pim_0 = parameters[global_param_ids[5]];
 }

--- a/src/model/OpenLoopCoronaryBC.cpp
+++ b/src/model/OpenLoopCoronaryBC.cpp
@@ -74,12 +74,12 @@ void OpenLoopCoronaryBC::update_time(SparseSystem &system,
   auto Pv = parameters[global_param_ids[6]];
 
   if (steady) {
-    std::cout<<this->P_Cim_0 << " " <<this->Pim_0<<std::endl;
+    //std::cout<<this->P_Cim_0 << " " <<this->Pim_0<<std::endl;
     //system.C(global_eqn_ids[0]) = -Cim * Pim;
 //  system.C(global_eqn_ids[0]) = Cim * (Pim - this->Pim_0 + this->P_Cim_0);
     system.C(global_eqn_ids[1]) = Pv;
   } else {
-    std::cout<<this->P_Cim_0 << " " <<this->Pim_0<<std::endl;
+    //std::cout<<this->P_Cim_0 << " " <<this->Pim_0<<std::endl;
     //system.C(global_eqn_ids[0]) = Cim * (-Pim + Pv);
     system.C(global_eqn_ids[0]) = Cim * (-Pim + Pv + this->Pim_0 - this->P_Cim_0);
     system.C(global_eqn_ids[1]) = (Ram * Cim * Pv) - Cim * (Rv + Ram) * (Pim + this->P_Cim_0 - this->Pim_0);
@@ -87,10 +87,10 @@ void OpenLoopCoronaryBC::update_time(SparseSystem &system,
 }
 
 void OpenLoopCoronaryBC::setup_initial_state_dependent_params(State initial_state, std::vector<double> &parameters) {
-  if (steady) {
+//if (steady) {
 //  this->P_Cim_0 = 220.0;
 //  this->Pim_0 = parameters[global_param_ids[5]];
-  } else {
+//} else {
     //P_Cim_0 = 0.0;
     //Pim_0 = 0.0;
     //auto Rv = parameters[global_param_ids[2]];
@@ -110,5 +110,5 @@ void OpenLoopCoronaryBC::setup_initial_state_dependent_params(State initial_stat
     //std::cout << P_Ca << " " << P_Ca_dot << " " << Ram << " " << Q_am << std::endl;
     this->P_Cim_0 = P_Ca - Ram*Q_am;
     this->Pim_0 = parameters[global_param_ids[5]];
-  }
+//}
 }

--- a/src/model/OpenLoopCoronaryBC.cpp
+++ b/src/model/OpenLoopCoronaryBC.cpp
@@ -83,7 +83,9 @@ void OpenLoopCoronaryBC::update_time(SparseSystem &system,
   }
 }
 
-void OpenLoopCoronaryBC::setup_initial_state_dependent_params(State initial_state) {
+void OpenLoopCoronaryBC::setup_initial_state_dependent_params(State initial_state, std::vector<double> &parameters) {
   P_Cim_0 = 0.0;
   Pim_0 = 0.0;
+  //auto Pim = parameters[global_param_ids[5]];
+  //Pim_0 = Pim.get(0.0);
 }

--- a/src/model/OpenLoopCoronaryBC.cpp
+++ b/src/model/OpenLoopCoronaryBC.cpp
@@ -84,8 +84,22 @@ void OpenLoopCoronaryBC::update_time(SparseSystem &system,
 }
 
 void OpenLoopCoronaryBC::setup_initial_state_dependent_params(State initial_state, std::vector<double> &parameters) {
-  P_Cim_0 = 0.0;
-  Pim_0 = 0.0;
-  //auto Pim = parameters[global_param_ids[5]];
-  //Pim_0 = Pim.get(0.0);
+  //P_Cim_0 = 0.0;
+  //Pim_0 = 0.0;
+  //auto Rv = parameters[global_param_ids[2]];
+  //auto Pv = parameters[global_param_ids[6]];
+  //auto Q_im = initial_state.ydot[global_var_ids[2]];
+  auto P_in = initial_state.y[global_var_ids[0]];
+  auto Q_in = initial_state.y[global_var_ids[1]];
+  auto P_in_dot = initial_state.ydot[global_var_ids[0]];
+  auto Q_in_dot = initial_state.ydot[global_var_ids[1]];
+  auto Ra = parameters[global_param_ids[0]];
+  auto Ram = parameters[global_param_ids[1]];
+  auto Ca = parameters[global_param_ids[3]];
+  auto P_Ca = P_in - Ra*Q_in;
+  auto P_Ca_dot = P_in_dot - Ra*Q_in_dot; 
+  auto Q_am = Q_in - Ca*P_Ca_dot;
+  P_Cim_0 = P_Ca - Ram*Q_am;
+  //P_Cim_0 = Pv + Rv*Q_out;
+  Pim_0 = parameters[global_param_ids[5]];
 }

--- a/src/model/OpenLoopCoronaryBC.cpp
+++ b/src/model/OpenLoopCoronaryBC.cpp
@@ -76,12 +76,16 @@ void OpenLoopCoronaryBC::update_time(SparseSystem &system,
   if (steady) {
     system.C(global_eqn_ids[1]) = Pv;
   } else {
-    system.C(global_eqn_ids[0]) = Cim * (-Pim + Pv + this->Pim_0 - this->P_Cim_0);
-    system.C(global_eqn_ids[1]) = (Ram * Cim * Pv) - Cim * (Rv + Ram) * (Pim + this->P_Cim_0 - this->Pim_0);
+    system.C(global_eqn_ids[0]) =
+        Cim * (-Pim + Pv + this->Pim_0 - this->P_Cim_0);
+    system.C(global_eqn_ids[1]) =
+        (Ram * Cim * Pv) -
+        Cim * (Rv + Ram) * (Pim + this->P_Cim_0 - this->Pim_0);
   }
 }
 
-void OpenLoopCoronaryBC::setup_initial_state_dependent_params(State initial_state, std::vector<double> &parameters) {
+void OpenLoopCoronaryBC::setup_initial_state_dependent_params(
+    State initial_state, std::vector<double> &parameters) {
   auto P_in = initial_state.y[global_var_ids[0]];
   auto Q_in = initial_state.y[global_var_ids[1]];
   auto P_in_dot = initial_state.ydot[global_var_ids[0]];
@@ -90,12 +94,12 @@ void OpenLoopCoronaryBC::setup_initial_state_dependent_params(State initial_stat
   auto Ram = parameters[global_param_ids[1]];
   auto Ca = parameters[global_param_ids[3]];
   // Pressure proximal to Ca and distal to Ra
-  auto P_Ca = P_in - Ra*Q_in;
-  auto P_Ca_dot = P_in_dot - Ra*Q_in_dot;
+  auto P_Ca = P_in - Ra * Q_in;
+  auto P_Ca_dot = P_in_dot - Ra * Q_in_dot;
   // Flow into Ram (inflow minus flow into Ca)
-  auto Q_am = Q_in - Ca*P_Ca_dot;
+  auto Q_am = Q_in - Ca * P_Ca_dot;
   // Pressure proximal to Cim/Vim and distal to Ram
-  this->P_Cim_0 = P_Ca - Ram*Q_am;
+  this->P_Cim_0 = P_Ca - Ram * Q_am;
   // Initial intramyocardial pressure
   this->Pim_0 = parameters[global_param_ids[5]];
 }

--- a/src/model/OpenLoopCoronaryBC.cpp
+++ b/src/model/OpenLoopCoronaryBC.cpp
@@ -79,7 +79,7 @@ void OpenLoopCoronaryBC::update_time(SparseSystem &system,
   } else {
     //system.C(global_eqn_ids[0]) = Cim * (-Pim + Pv);
     system.C(global_eqn_ids[0]) = Cim * (-Pim + Pv + this->Pim_0 - this->P_Cim_0);
-    system.C(global_eqn_ids[1]) = -Cim * (Rv + Ram) * Pim + Ram * Cim * Pv -Cim * (Rv + Ram) * (this->P_Cim_0 - this->Pim_0);
+    system.C(global_eqn_ids[1]) = -Cim * (Rv + Ram) * Pim + (Ram * Cim * Pv) - (Cim * (Rv + Ram) * (this->P_Cim_0 - this->Pim_0));
   }
 }
 

--- a/src/model/OpenLoopCoronaryBC.h
+++ b/src/model/OpenLoopCoronaryBC.h
@@ -60,15 +60,16 @@
  * ### Governing equations
  *
  * \f[
- * C_{i m} R_{v} Q_{in}-V_{i m}+C_{i m} \left(-P_{c i m}(0)+P_{i m}(0)-P_{i m}+P_{v}\right)-C_{i m} R_{v}
- * \frac{d V_{i m}}{d t}-C_{a} C_{i m} R_{v} \frac{d P_{in}}{d t}+R_{a} C_{a}
- * C_{i m} R_{v} \frac{d Q_{in}}{d t}+C_{a} C_{i m} R_{v} \frac{d P_{a}}{d
- * t}=0 \f]
+ * C_{i m} R_{v} Q_{in}-V_{i m}+C_{i m} \left(-P_{c i m}(0)+P_{i m}(0)-P_{i
+ * m}+P_{v}\right)-C_{i m} R_{v} \frac{d V_{i m}}{d t}-C_{a} C_{i m} R_{v}
+ * \frac{d P_{in}}{d t}+R_{a} C_{a} C_{i m} R_{v} \frac{d Q_{in}}{d t}+C_{a}
+ * C_{i m} R_{v} \frac{d P_{a}}{d t}=0 \f]
  *
  * \f[
- * C_{i m} R_v P_{in}-C_{i m} R_{v} R_{a} Q_{in}-R_{v} V_{i m}-C_{i m}\left(R_{v}+R_{a m}\right)
- * \left(P_{c i m}(0)-P_{i m}(0)+P_{i m}\right)-C_{i m} R_{v} R_{a m} \frac{d V_{i m}}{d t}
- * -R_{a m} V_{i m}+R_{a m} C_{i m} P_{v}=0 \f]
+ * C_{i m} R_v P_{in}-C_{i m} R_{v} R_{a} Q_{in}-R_{v} V_{i m}-C_{i
+ * m}\left(R_{v}+R_{a m}\right) \left(P_{c i m}(0)-P_{i m}(0)+P_{i
+ * m}\right)-C_{i m} R_{v} R_{a m} \frac{d V_{i m}}{d t} -R_{a m} V_{i m}+R_{a
+ * m} C_{i m} P_{v}=0 \f]
  *
  * ### Local contributions
  *
@@ -86,8 +87,10 @@
  * & -C_{i m} R_{v} R_{a} & -\left(R_{v}+R_{a m}\right)\end{array}\right] \f]
  *
  * \f[
- * \mathbf{c}^{e}=\left[\begin{array}{c}C_{i m}\left(-P_{i m}+P_{i m}(0)-P_{c i m}(0)+P_{v}\right)+C_{a}
- * C_{i m} R_{v} \frac{d P_{a}}{d t} \\-C_{i m}\left(R_{v} + R_{a m}\right)\left(P_{cim}(0)-P_{i m}(0)+P_{i m}\right)+R_{a m} C_{i m} P_{v}\end{array}\right] \f]
+ * \mathbf{c}^{e}=\left[\begin{array}{c}C_{i m}\left(-P_{i m}+P_{i m}(0)-P_{c i
+ * m}(0)+P_{v}\right)+C_{a} C_{i m} R_{v} \frac{d P_{a}}{d t} \\-C_{i
+ * m}\left(R_{v} + R_{a m}\right)\left(P_{cim}(0)-P_{i m}(0)+P_{i m}\right)+R_{a
+ * m} C_{i m} P_{v}\end{array}\right] \f]
  *
  * Assume \f$P_a=0\f$.
  *
@@ -149,7 +152,8 @@ class OpenLoopCoronaryBC : public Block {
    * @param initial_state The initial state of the system
    * @param parameters The parameter values vector (at time 0)
    */
-  void setup_initial_state_dependent_params(State initial_state, std::vector<double> &parameters);
+  void setup_initial_state_dependent_params(State initial_state,
+                                            std::vector<double> &parameters);
 
   /**
    * @brief Update the constant contributions of the element in a sparse system

--- a/src/model/OpenLoopCoronaryBC.h
+++ b/src/model/OpenLoopCoronaryBC.h
@@ -144,6 +144,13 @@ class OpenLoopCoronaryBC : public Block {
   void setup_dofs(DOFHandler &dofhandler);
 
   /**
+   * @brief Setup parameters that depend on the initial state
+   *
+   * @param initial_state The initial state of the system
+   */
+  void setup_initial_state_dependent_params(State initial_state);
+
+  /**
    * @brief Update the constant contributions of the element in a sparse system
    *
    * @param system System to update contributions at
@@ -167,6 +174,10 @@ class OpenLoopCoronaryBC : public Block {
    * (relevant for sparse memory reservation)
    */
   TripletsContributions num_triplets{5, 4, 0};
+
+ protected:
+  double P_Cim_0 = 0;  ///< Pressure proximal to Cim/Vim at initial state
+  double Pim_0 = 0;    ///< Pim at initial state
 };
 
 #endif  // SVZERODSOLVER_MODEL_OPENLOOPCORONARYBC_HPP_

--- a/src/model/OpenLoopCoronaryBC.h
+++ b/src/model/OpenLoopCoronaryBC.h
@@ -62,13 +62,13 @@
  * \f[
  * C_{i m} R_{v} Q_{in}-V_{i m}+C_{i m} \left(-P_{c i m}(0)+P_{i m}(0)-P_{i
  * m}+P_{v}\right)-C_{i m} R_{v} \frac{d V_{i m}}{d t}-C_{a} C_{i m} R_{v}
- * \frac{d P_{in}}{d t}+R_{a} C_{a} C_{i m} R_{v} \frac{d Q_{in}}{d t}+C_{a}
+ * \frac{d P_{in}}{d t}+R_{a} C_{a} C_{i m} R_{v} \frac{d Q_{in}}{d t}\\+C_{a}
  * C_{i m} R_{v} \frac{d P_{a}}{d t}=0 \f]
  *
  * \f[
  * C_{i m} R_v P_{in}-C_{i m} R_{v} R_{a} Q_{in}-R_{v} V_{i m}-C_{i
  * m}\left(R_{v}+R_{a m}\right) \left(P_{c i m}(0)-P_{i m}(0)+P_{i
- * m}\right)-C_{i m} R_{v} R_{a m} \frac{d V_{i m}}{d t} -R_{a m} V_{i m}+R_{a
+ * m}\right)-C_{i m} R_{v} R_{a m} \frac{d V_{i m}}{d t} \\-R_{a m} V_{i m}+R_{a
  * m} C_{i m} P_{v}=0 \f]
  *
  * ### Local contributions

--- a/src/model/OpenLoopCoronaryBC.h
+++ b/src/model/OpenLoopCoronaryBC.h
@@ -177,6 +177,8 @@ class OpenLoopCoronaryBC : public Block {
   TripletsContributions num_triplets{5, 4, 0};
 
  protected:
+  //double P_Cim_0 = 220;  ///< Pressure proximal to Cim/Vim at initial state
+  //double Pim_0 = 1000;    ///< Pim at initial state
   double P_Cim_0 = 0;  ///< Pressure proximal to Cim/Vim at initial state
   double Pim_0 = 0;    ///< Pim at initial state
 };

--- a/src/model/OpenLoopCoronaryBC.h
+++ b/src/model/OpenLoopCoronaryBC.h
@@ -71,6 +71,13 @@
  * m}\right)-C_{i m} R_{v} R_{a m} \frac{d V_{i m}}{d t} \\-R_{a m} V_{i m}+R_{a
  * m} C_{i m} P_{v}=0 \f]
  *
+ * \f{eqnarray*}{
+ * &C_{i m} R_v P_{in}-C_{i m} R_{v} R_{a} Q_{in}-R_{v} V_{i m}-C_{i
+ * m}\left(R_{v}+R_{a m}\right) \left(P_{c i m}(0)-P_{i m}(0)+P_{i
+ * m}\right)-C_{i m} R_{v} R_{a m} \frac{d V_{i m}}{d t} \\ &-R_{a m} V_{i m}+R_{a
+ * m} C_{i m} P_{v}=0 
+ * \f}
+ *
  * ### Local contributions
  *
  * \f[

--- a/src/model/OpenLoopCoronaryBC.h
+++ b/src/model/OpenLoopCoronaryBC.h
@@ -147,8 +147,9 @@ class OpenLoopCoronaryBC : public Block {
    * @brief Setup parameters that depend on the initial state
    *
    * @param initial_state The initial state of the system
+   * @param parameters The parameter values vector (at time 0)
    */
-  void setup_initial_state_dependent_params(State initial_state);
+  void setup_initial_state_dependent_params(State initial_state, std::vector<double> &parameters);
 
   /**
    * @brief Update the constant contributions of the element in a sparse system

--- a/src/model/OpenLoopCoronaryBC.h
+++ b/src/model/OpenLoopCoronaryBC.h
@@ -60,15 +60,15 @@
  * ### Governing equations
  *
  * \f[
- * C_{i m} R_{v} Q_{in}-V_{i m}+C_{i m} (-P_{i m}+P_{v})-C_{i m}\left(P_{c i m}(0)-P_{i m}(0)\right)-C_{i m} R_{v}
+ * C_{i m} R_{v} Q_{in}-V_{i m}+C_{i m} (-P_{c i m}(0)+P_{i m}(0)-P_{i m}+P_{v})-C_{i m} R_{v}
  * \frac{d V_{i m}}{d t}-C_{a} C_{i m} R_{v} \frac{d P_{in}}{d t}+R_{a} C_{a}
  * C_{i m} R_{v} \frac{d Q_{in}}{d t}+C_{a} C_{i m} R_{v} \frac{d P_{a}}{d
  * t}=0 \f]
  *
  * \f[
- * C_{i m} R_v P_{in}-C_{i m} R_{v} R_{a} Q_{in}-R_{v} V_{i m}-C_{i m} R_{v}
- * P_{i m}-C_{i m}R_{v}\left(P_{c i m}(0)-P_{i m}(0)\right)-C_{i m} R_{v} R_{a m} \frac{d V_{i m}}{d t}-R_{a m} V_{i
- * m}-C_{i m} R_{a m} P_{i m}-C_{i m}R_{a m}\left(P_{c i m}(0)-P_{i m}(0)\right)+R_{a m} C_{i m} P_{v}=0 \f]
+ * C_{i m} R_v P_{in}-C_{i m} R_{v} R_{a} Q_{in}-R_{v} V_{i m}-C_{i m}(R_{v}_R_{a m})
+ * \left(P_{c i m}(0)-P_{i m}(0)+P_{i m}\right)-C_{i m} R_{v} R_{a m} \frac{d V_{i m}}{d t}
+ * -R_{a m} V_{i m}+R_{a m} C_{i m} P_{v}=0 \f]
  *
  * ### Local contributions
  *
@@ -86,9 +86,8 @@
  * & -C_{i m} R_{v} R_{a} & -\left(R_{v}+R_{a m}\right)\end{array}\right] \f]
  *
  * \f[
- * \mathbf{c}^{e}=\left[\begin{array}{c}C_{i m}\left(-P_{i m}+P_{v}\right)-C_{i m}\left(P_{c i m}(0)-P_{i m}(0)\right)+C_{a}
- * C_{i m} R_{v} \frac{d P_{a}}{d t} \\-C_{i m}\left(R_{v}+R_{a m}\right) P_{i
- * m}-C_{i m}\left(R_{a m} + R_{v}\right)\left(P_{cim}(0)-P_{i m}(0)\right)+R_{a m} C_{i m} P_{v}\end{array}\right] \f]
+ * \mathbf{c}^{e}=\left[\begin{array}{c}C_{i m}\left(-P_{i m}+P_{i m}(0)-P_{c i m}(0)+P_{v}\right)+C_{a}
+ * C_{i m} R_{v} \frac{d P_{a}}{d t} \\-C_{i m}\left(R_{v} + R_{a m}\right)\left(P_{cim}(0)-P_{i m}(0)+P_{i m}\right)+R_{a m} C_{i m} P_{v}\end{array}\right] \f]
  *
  * Assume \f$P_a=0\f$.
  *

--- a/src/model/OpenLoopCoronaryBC.h
+++ b/src/model/OpenLoopCoronaryBC.h
@@ -45,8 +45,9 @@
  * \begin{circuitikz} \draw
  * node[left] {$Q_{in}$} [-latex] (0,0) -- (0.8,0);
  * \draw (1,0) node[anchor=south]{$P_{in}$}
- * to [R, l=$R_a$, *-] (3,0)
+ * to [R, l=$R_a$, *-*] (3,0)
  * to [R, l=$R_{am}$, -] (5,0)
+ * node[anchor=south]{$P_{cim}$}
  * to [R, l=$R_v$, *-*] (7,0)
  * node[anchor=south]{$P_{v}$}
  * (5,0) to [C, l=$C_{im} \;V_{im}$, -*] (5,-1.5)
@@ -59,15 +60,15 @@
  * ### Governing equations
  *
  * \f[
- * C_{i m} R_{v} Q_{in}-V_{i m}-C_{i m} P_{i m}+C_{i m} P_{v}-C_{i m} R_{v}
+ * C_{i m} R_{v} Q_{in}-V_{i m}+C_{i m} (-P_{i m}+P_{v})-C_{i m}\left(P_{c i m}(0)-P_{i m}(0)\right)-C_{i m} R_{v}
  * \frac{d V_{i m}}{d t}-C_{a} C_{i m} R_{v} \frac{d P_{in}}{d t}+R_{a} C_{a}
  * C_{i m} R_{v} \frac{d Q_{in}}{d t}+C_{a} C_{i m} R_{v} \frac{d P_{a}}{d
  * t}=0 \f]
  *
  * \f[
- * C_{i m} R_v P^{e}-C_{i m} R_{v} R_{a} Q^{e}-R_{v} V_{i m}^{e}-C_{i m} R_{v}
- * P_{i m}-C_{i m} R_{v} R_{a m} \frac{d V_{i m}^{e}}{d t}-R_{a m} V_{i
- * m}^{e}-C_{i m} R_{a m} P_{i m}+R_{a m} C_{i m} P_{v}=0 \f]
+ * C_{i m} R_v P_{in}-C_{i m} R_{v} R_{a} Q_{in}-R_{v} V_{i m}-C_{i m} R_{v}
+ * P_{i m}-C_{i m}R_{v}\left(P_{c i m}(0)-P_{i m}(0)\right)-C_{i m} R_{v} R_{a m} \frac{d V_{i m}}{d t}-R_{a m} V_{i
+ * m}-C_{i m} R_{a m} P_{i m}-C_{i m}R_{a m}\left(P_{c i m}(0)-P_{i m}(0)\right)+R_{a m} C_{i m} P_{v}=0 \f]
  *
  * ### Local contributions
  *
@@ -85,9 +86,9 @@
  * & -C_{i m} R_{v} R_{a} & -\left(R_{v}+R_{a m}\right)\end{array}\right] \f]
  *
  * \f[
- * \mathbf{c}^{e}=\left[\begin{array}{c}C_{i m}\left(-P_{i m}+P_{v}\right)+C_{a}
+ * \mathbf{c}^{e}=\left[\begin{array}{c}C_{i m}\left(-P_{i m}+P_{v}\right)-C_{i m}\left(P_{c i m}(0)-P_{i m}(0)\right)+C_{a}
  * C_{i m} R_{v} \frac{d P_{a}}{d t} \\-C_{i m}\left(R_{v}+R_{a m}\right) P_{i
- * m}+R_{a m} C_{i m} P_{v}\end{array}\right] \f]
+ * m}-C_{i m}\left(R_{a m} + R_{v}\right)\left(P_{cim}(0)-P_{i m}(0)\right)+R_{a m} C_{i m} P_{v}\end{array}\right] \f]
  *
  * Assume \f$P_a=0\f$.
  *

--- a/src/model/OpenLoopCoronaryBC.h
+++ b/src/model/OpenLoopCoronaryBC.h
@@ -60,13 +60,13 @@
  * ### Governing equations
  *
  * \f[
- * C_{i m} R_{v} Q_{in}-V_{i m}+C_{i m} (-P_{c i m}(0)+P_{i m}(0)-P_{i m}+P_{v})-C_{i m} R_{v}
+ * C_{i m} R_{v} Q_{in}-V_{i m}+C_{i m} \left(-P_{c i m}(0)+P_{i m}(0)-P_{i m}+P_{v}\right)-C_{i m} R_{v}
  * \frac{d V_{i m}}{d t}-C_{a} C_{i m} R_{v} \frac{d P_{in}}{d t}+R_{a} C_{a}
  * C_{i m} R_{v} \frac{d Q_{in}}{d t}+C_{a} C_{i m} R_{v} \frac{d P_{a}}{d
  * t}=0 \f]
  *
  * \f[
- * C_{i m} R_v P_{in}-C_{i m} R_{v} R_{a} Q_{in}-R_{v} V_{i m}-C_{i m}(R_{v}_R_{a m})
+ * C_{i m} R_v P_{in}-C_{i m} R_{v} R_{a} Q_{in}-R_{v} V_{i m}-C_{i m}\left(R_{v}+R_{a m}\right)
  * \left(P_{c i m}(0)-P_{i m}(0)+P_{i m}\right)-C_{i m} R_{v} R_{a m} \frac{d V_{i m}}{d t}
  * -R_{a m} V_{i m}+R_{a m} C_{i m} P_{v}=0 \f]
  *
@@ -177,8 +177,6 @@ class OpenLoopCoronaryBC : public Block {
   TripletsContributions num_triplets{5, 4, 0};
 
  protected:
-  //double P_Cim_0 = 220;  ///< Pressure proximal to Cim/Vim at initial state
-  //double Pim_0 = 1000;    ///< Pim at initial state
   double P_Cim_0 = 0;  ///< Pressure proximal to Cim/Vim at initial state
   double Pim_0 = 0;    ///< Pim at initial state
 };

--- a/src/model/OpenLoopCoronaryBC.h
+++ b/src/model/OpenLoopCoronaryBC.h
@@ -59,24 +59,18 @@
  *
  * ### Governing equations
  *
- * \f[
- * C_{i m} R_{v} Q_{in}-V_{i m}+C_{i m} \left(-P_{c i m}(0)+P_{i m}(0)-P_{i
+ * \f{eqnarray*}{
+ * &C_{i m} R_{v} Q_{in}-V_{i m}+C_{i m} \left(-P_{c i m}(0)+P_{i m}(0)-P_{i
  * m}+P_{v}\right)-C_{i m} R_{v} \frac{d V_{i m}}{d t}-C_{a} C_{i m} R_{v}
- * \frac{d P_{in}}{d t}+R_{a} C_{a} C_{i m} R_{v} \frac{d Q_{in}}{d t}\\+C_{a}
- * C_{i m} R_{v} \frac{d P_{a}}{d t}=0 \f]
- *
- * \f[
- * C_{i m} R_v P_{in}-C_{i m} R_{v} R_{a} Q_{in}-R_{v} V_{i m}-C_{i
- * m}\left(R_{v}+R_{a m}\right) \left(P_{c i m}(0)-P_{i m}(0)+P_{i
- * m}\right)-C_{i m} R_{v} R_{a m} \frac{d V_{i m}}{d t} \\-R_{a m} V_{i m}+R_{a
- * m} C_{i m} P_{v}=0 \f]
+ * \frac{d P_{in}}{d t}+R_{a} C_{a} C_{i m} R_{v} \frac{d Q_{in}}{d t}\\ &+C_{a}
+ * C_{i m} R_{v} \frac{d P_{a}}{d t}=0
+ * \f}
  *
  * \f{eqnarray*}{
  * &C_{i m} R_v P_{in}-C_{i m} R_{v} R_{a} Q_{in}-R_{v} V_{i m}-C_{i
  * m}\left(R_{v}+R_{a m}\right) \left(P_{c i m}(0)-P_{i m}(0)+P_{i
- * m}\right)-C_{i m} R_{v} R_{a m} \frac{d V_{i m}}{d t} \\ &-R_{a m} V_{i m}+R_{a
- * m} C_{i m} P_{v}=0 
- * \f}
+ * m}\right)-C_{i m} R_{v} R_{a m} \frac{d V_{i m}}{d t} \\ &-R_{a m} V_{i
+ * m}+R_{a m} C_{i m} P_{v}=0 \f}
  *
  * ### Local contributions
  *

--- a/src/model/WindkesselBC.h
+++ b/src/model/WindkesselBC.h
@@ -58,11 +58,11 @@
  * ### Governing equations
  *
  * \f[
- * R_{d} Q^{e}-P_{c}^{e}+P_{r e f}-R_{d} C \frac{d P_{c}^{e}}{d t}=0
+ * R_{d} Q_{in}-P_{c}+P_{r e f}-R_{d} C \frac{d P_{c}}{d t}=0
  * \f]
  *
  * \f[
- * P^{e}-P_{c}^{e}-R_{p} Q^{e}=0
+ * P_{in}-P_{c}-R_{p} Q_{in}=0
  * \f]
  *
  * ### Local contributions

--- a/src/solve/Solver.cpp
+++ b/src/solve/Solver.cpp
@@ -45,6 +45,8 @@ void Solver::run() {
     DEBUG_MSG("Calculate steady initial condition");
     double time_step_size_steady = this->model->cardiac_cycle_period / 10.0;
     this->model->to_steady();
+    
+    this->model->setup_initial_state_dependent_parameters(state);
 
     Integrator integrator_steady(this->model.get(), time_step_size_steady,
                                  simparams.sim_rho_infty, simparams.sim_abs_tol,

--- a/src/solve/Solver.cpp
+++ b/src/solve/Solver.cpp
@@ -57,6 +57,8 @@ void Solver::run() {
     this->model->to_unsteady();
   }
 
+  this->model->setup_initial_state_dependent_parameters(state);
+
   // Set-up integrator
   DEBUG_MSG("Setup time integration");
   Integrator integrator(this->model.get(), simparams.sim_time_step_size,

--- a/src/solve/Solver.cpp
+++ b/src/solve/Solver.cpp
@@ -40,14 +40,12 @@ Solver::Solver(const nlohmann::json& config) {
 void Solver::run() {
   auto state = initial_state;
 
-  // Create steady initial
+  // Create steady initial condition
   if (simparams.sim_steady_initial) {
     DEBUG_MSG("Calculate steady initial condition");
     double time_step_size_steady = this->model->cardiac_cycle_period / 10.0;
     this->model->to_steady();
     
-    this->model->setup_initial_state_dependent_parameters(state);
-
     Integrator integrator_steady(this->model.get(), time_step_size_steady,
                                  simparams.sim_rho_infty, simparams.sim_abs_tol,
                                  simparams.sim_nliter);
@@ -59,6 +57,8 @@ void Solver::run() {
     this->model->to_unsteady();
   }
 
+  // Use the initial condition (steady or user-provided) to set up parameters 
+  // which depend on the initial condition
   this->model->setup_initial_state_dependent_parameters(state);
 
   // Set-up integrator

--- a/src/solve/Solver.cpp
+++ b/src/solve/Solver.cpp
@@ -45,7 +45,7 @@ void Solver::run() {
     DEBUG_MSG("Calculate steady initial condition");
     double time_step_size_steady = this->model->cardiac_cycle_period / 10.0;
     this->model->to_steady();
-    
+
     Integrator integrator_steady(this->model.get(), time_step_size_steady,
                                  simparams.sim_rho_infty, simparams.sim_abs_tol,
                                  simparams.sim_nliter);
@@ -57,7 +57,7 @@ void Solver::run() {
     this->model->to_unsteady();
   }
 
-  // Use the initial condition (steady or user-provided) to set up parameters 
+  // Use the initial condition (steady or user-provided) to set up parameters
   // which depend on the initial condition
   this->model->setup_initial_state_dependent_parameters(state);
 


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation
Closes #107 

The equations for the open loop coronary block were missing a few terms relating to the initial condition. While fixing this, I also noticed that the equation for the steady state initial condition was wrong. 


## Release Notes 
* Added new functions `Block::setup_initial_state_dependent_params` and `Model::setup_initial_state_dependent_parameters` to set up block-specific parameters that depend on the initial state vector
* Added new terms to the OpenLoopCoronary equations to account for the initial condition.
* Fixed the steady state equations for OpenLoopCoronaryBC
* Miscellaneous: Minor edits to the WindkesselBC documentation
* Miscellaneous: Allow a user to run the solver without specifying the name of the output. Default output file will be written with name `output.csv`. This is already a feature when running using the Python API. Just added it to the CMake build executable. 

## Documentation
 <!-- todo developers: add documentation guide -->
* Updated docs to add new equations for OpenLoopCoronaryBC

## Testing
Tests passing. 


## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
