### PR TITLE
update docs to reflect gcc sherlock version

### DIFF
--- a/docs/pages/main.md
+++ b/docs/pages/main.md
@@ -92,10 +92,10 @@ cmake --build .
   <summary>**Building on Sherlock**</summary>
 
 ```bash
-module load cmake/3.23.1 gcc/12.1.0 binutils/2.38
+module load cmake/3.23.1 gcc/14.2.0 binutils/2.38
 mkdir Release
 cd Release
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=/share/software/user/open/gcc/12.1.0/bin/g++ -DCMAKE_C_COMPILER=/share/software/user/open/gcc/12.1.0/bin/gcc ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=/share/software/user/open/gcc/14.2.0/bin/g++ -DCMAKE_C_COMPILER=/share/software/user/open/gcc/14.2.0/bin/gcc ..
 cmake --build .
 ```
 


### PR DESCRIPTION
Update documentation to reflect correct gcc version on sherlock

## Current situation
Currently, the gcc version specified in the documentation (12.1.0) does not exist on sherlock anymore


## Release Notes 
The version of gcc in the sherlock build documentation has been updated to 14.2.0

## Documentation
documentation main page was changed slightly


## Testing
N/A


## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
