### PR TITLE
Specify GCC and clang-format versions in Github runners

### DIFF
--- a/.github/workflows/codechecks.yml
+++ b/.github/workflows/codechecks.yml
@@ -8,6 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo apt install clang-format-20
       - name: Run clang-format
         run: |

--- a/.github/workflows/codechecks.yml
+++ b/.github/workflows/codechecks.yml
@@ -8,8 +8,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt install clang-format-20
+          #wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo apt-get install clang-format-20
       - name: Run clang-format
         run: |
           mkdir Release

--- a/.github/workflows/codechecks.yml
+++ b/.github/workflows/codechecks.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          sudo apt install clang-format
+          sudo apt install clang-format-20
       - name: Run clang-format
         run: |
           mkdir Release

--- a/.github/workflows/codechecks.yml
+++ b/.github/workflows/codechecks.yml
@@ -8,9 +8,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          #wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          sudo apt-get install clang-format-20
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          #wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo apt-get install clang-format-19
       - name: Run clang-format
         run: |
           mkdir Release

--- a/.github/workflows/codechecks.yml
+++ b/.github/workflows/codechecks.yml
@@ -9,8 +9,7 @@ jobs:
       - name: Install dependencies
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          #wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          sudo apt-get install clang-format-20
+          sudo apt-get install clang-format-19
       - name: Run clang-format
         run: |
           mkdir Release

--- a/.github/workflows/codechecks.yml
+++ b/.github/workflows/codechecks.yml
@@ -10,7 +10,7 @@ jobs:
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           #wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          sudo apt-get install clang-format-19
+          sudo apt-get install clang-format-20
       - name: Run clang-format
         run: |
           mkdir Release

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ jobs:
           doxyfile-path: 'docs/Doxyfile'
           enable-latex: true
       - name: Save documentation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: documentation
           path: ./docs/build/html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,10 @@ jobs:
           conda create -n zerod python=3.11.4
           echo "Created environment"
           strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX
+          echo "test1"
+          conda run -n zerod install libgcc-ng
+          echo "test2"
+          conda run -n zerod install -c conda-forge libgcc-ng
           echo "Checked versions"
           conda run -n zerod pip install -e ".[dev]"
           strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Install ubuntu dependencies
         if: startsWith(matrix.os, 'ubuntu')
         run: sudo apt update && sudo apt install build-essential cmake lcov
+        run: sudo apt install --only-upgrade libstdc++6
       - name: Install svZeroDSolver
         run: |
           #export PATH="/usr/share/miniconda/bin:$PATH"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           auto-update-conda: true
       - name: Install ubuntu dependencies
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt update && sudo apt install build-essential cmake lcov && strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX && strings /usr/share/miniconda/envs/zerod/lib/libstdc++.so.6 | grep GLIBCXX
+        run: sudo apt update && sudo apt install build-essential cmake lcov && strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
       - name: Install svZeroDSolver
         run: |
           #export PATH="/usr/share/miniconda/bin:$PATH"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,8 @@ jobs:
           #echo "test1"
           #conda install -n zerod libgcc-ng
           echo "test2"
-          conda install -n zerod -c conda-forge libgcc-ng
+          #conda install -n zerod -c conda-forge libgcc-ng
+          conda install -n zerod -c conda-forge libstdcxx-ng=13
           echo "Checked versions"
           conda run -n zerod pip install -e ".[dev]"
           strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,11 @@ jobs:
           #export PATH="/usr/share/miniconda/bin:$PATH"
           #alias conda="$CONDA/bin/conda"
           conda create -n zerod python=3.11.4
+          echo "Created environment"
           strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX
-          #conda run -n zerod install -c conda-forge libstdcxx-ng --update-deps
-          conda run -n zerod install -c conda-forge libstdcxx-ng
-          strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX
+          echo "Checked versions"
           conda run -n zerod pip install -e ".[dev]"
+          strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX
       - name: Install Networkx
         run: |
             conda run -n zerod pip install networkx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,15 @@ jobs:
           auto-update-conda: true
       - name: Install ubuntu dependencies
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt update && sudo apt install build-essential cmake lcov && strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX && strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX
+        run: sudo apt update && sudo apt install build-essential cmake lcov && strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 
       - name: Install svZeroDSolver
         run: |
           #export PATH="/usr/share/miniconda/bin:$PATH"
           #alias conda="$CONDA/bin/conda"
           conda create -n zerod python=3.11.4
+          grep GLIBCXX && strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX
+          conda run -n zerod install -c conda-forge libstdcxx-ng --update-deps
+          grep GLIBCXX && strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX
           conda run -n zerod pip install -e ".[dev]"
       - name: Install Networkx
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
           make coverage
       - name: Save coverage report
         if: startsWith(matrix.os, 'ubuntu-22.04')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage_report
           path: Release/coverage
@@ -74,7 +74,7 @@ jobs:
           cpack
           cp distribution/svZeroDSolver_* ..
       - name: Upload installer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }} installer
           path: svZeroDSolver_*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           auto-update-conda: true
       - name: Install ubuntu dependencies
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt update && sudo apt install build-essential cmake lcov && strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
+        run: sudo apt update && sudo apt install build-essential cmake lcov && strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX && strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX
       - name: Install svZeroDSolver
         run: |
           #export PATH="/usr/share/miniconda/bin:$PATH"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           auto-update-conda: true
       - name: Install ubuntu dependencies
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt update && sudo apt install build-essential cmake lcov && sudo apt install --only-upgrade libstdc++6
+        run: sudo apt update && sudo apt install build-essential cmake lcov && strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX && strings /usr/lib/gcc/x86_64-linux-gnu/13/libstdc++.so.6 | grep GLIBCXX && strings /usr/share/miniconda/envs/zerod/lib/libstdc++.so.6 | grep GLIBCXX
       - name: Install svZeroDSolver
         run: |
           #export PATH="/usr/share/miniconda/bin:$PATH"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,11 @@ jobs:
           #alias conda="$CONDA/bin/conda"
           conda create -n zerod python=3.11.4
       - name: Quick-fix dependencies to get correct version numbers
-        if: startsWith(matrix.os, 'ubuntu-latest')
-          conda install -n zerod -c conda-forge libstdcxx-ng=13
+        #if: startsWith(matrix.os, 'ubuntu-latest')
+        if: startsWith(matrix.os, 'ubuntu')
+        run: conda install -n zerod -c conda-forge libstdcxx-ng=13 gcc=13
+        if: startsWith(matrix.os, 'macos')
+        run: conda install -n zerod -c conda-forge gcc=13
       - name: Install svZeroDSolver
           conda run -n zerod pip install -e ".[dev]"
       - name: Install Networkx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,11 @@ jobs:
           #export PATH="/usr/share/miniconda/bin:$PATH"
           #alias conda="$CONDA/bin/conda"
           conda create -n zerod python=3.11.4
-      - name: Quick-fix dependencies to get correct version numbers
+      - name: Install dependencies to get correct version numbers (Ubuntu)
         #if: startsWith(matrix.os, 'ubuntu-latest')
         if: startsWith(matrix.os, 'ubuntu')
         run: conda install -n zerod -c conda-forge libstdcxx-ng=13 gcc=13
+      - name: Install dependencies to get correct version numbers (MacOS)
         if: startsWith(matrix.os, 'macos')
         run: conda install -n zerod -c conda-forge gcc=13
       - name: Install svZeroDSolver

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: conda install -n zerod -c conda-forge gcc=13
       - name: Install svZeroDSolver
-          conda run -n zerod pip install -e ".[dev]"
+        run: conda run -n zerod pip install -e ".[dev]"
       - name: Install Networkx
         run: |
             conda run -n zerod pip install networkx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,15 +16,16 @@ jobs:
           auto-update-conda: true
       - name: Install ubuntu dependencies
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt update && sudo apt install build-essential cmake lcov && strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 
+        run: sudo apt update && sudo apt install build-essential cmake lcov && strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
       - name: Install svZeroDSolver
         run: |
           #export PATH="/usr/share/miniconda/bin:$PATH"
           #alias conda="$CONDA/bin/conda"
           conda create -n zerod python=3.11.4
-          grep GLIBCXX && strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX
-          conda run -n zerod install -c conda-forge libstdcxx-ng --update-deps
-          grep GLIBCXX && strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX
+          strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX
+          #conda run -n zerod install -c conda-forge libstdcxx-ng --update-deps
+          conda run -n zerod install -c conda-forge libstdcxx-ng
+          strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX
           conda run -n zerod pip install -e ".[dev]"
       - name: Install Networkx
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,10 @@ jobs:
           conda create -n zerod python=3.11.4
           echo "Created environment"
           strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX
-          echo "test1"
-          conda run -n zerod install libgcc-ng
+          #echo "test1"
+          #conda install -n zerod libgcc-ng
           echo "test2"
-          conda run -n zerod install -c conda-forge libgcc-ng
+          conda install -n zerod -c conda-forge libgcc-ng
           echo "Checked versions"
           conda run -n zerod pip install -e ".[dev]"
           strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-latest, macos-13, macos-latest]
+        version: [13] # GCC version
       fail-fast: false
+      env:
+        GCC_V: ${{ matrix.version }}
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3
@@ -23,12 +26,13 @@ jobs:
           #alias conda="$CONDA/bin/conda"
           conda create -n zerod python=3.11.4
       - name: Install dependencies to get correct version numbers (Ubuntu)
-        #if: startsWith(matrix.os, 'ubuntu-latest')
         if: startsWith(matrix.os, 'ubuntu')
-        run: conda install -n zerod -c conda-forge libstdcxx-ng=13 gcc=13
+        run: conda install -n zerod -c conda-forge libstdcxx-ng=${GCC_V} gcc=${GCC_V}
       - name: Install dependencies to get correct version numbers (MacOS)
         if: startsWith(matrix.os, 'macos')
-        run: conda install -n zerod -c conda-forge gcc=13
+        run: |
+          brew install gcc@${{ env.GCC_V }}
+          ln -s /usr/local/bin/gcc-${{ env.GCC_V }} /usr/local/bin/gcc
       - name: Install svZeroDSolver
         run: conda run -n zerod pip install -e ".[dev]"
       - name: Install Networkx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           auto-update-conda: true
       - name: Install ubuntu dependencies
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt update && sudo apt install build-essential cmake lcov && strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX && strings /usr/lib/gcc/x86_64-linux-gnu/13/libstdc++.so.6 | grep GLIBCXX && strings /usr/share/miniconda/envs/zerod/lib/libstdc++.so.6 | grep GLIBCXX
+        run: sudo apt update && sudo apt install build-essential cmake lcov && strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX && strings /usr/share/miniconda/envs/zerod/lib/libstdc++.so.6 | grep GLIBCXX
       - name: Install svZeroDSolver
         run: |
           #export PATH="/usr/share/miniconda/bin:$PATH"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,22 +16,17 @@ jobs:
           auto-update-conda: true
       - name: Install ubuntu dependencies
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt update && sudo apt install build-essential cmake lcov && strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
-      - name: Install svZeroDSolver
+        run: sudo apt update && sudo apt install build-essential cmake lcov
+      - name: Create conda environment
         run: |
           #export PATH="/usr/share/miniconda/bin:$PATH"
           #alias conda="$CONDA/bin/conda"
           conda create -n zerod python=3.11.4
-          echo "Created environment"
-          strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX
-          #echo "test1"
-          #conda install -n zerod libgcc-ng
-          echo "test2"
-          #conda install -n zerod -c conda-forge libgcc-ng
+      - name: Quick-fix dependencies to get correct version numbers
+        if: startsWith(matrix.os, 'ubuntu-latest')
           conda install -n zerod -c conda-forge libstdcxx-ng=13
-          echo "Checked versions"
+      - name: Install svZeroDSolver
           conda run -n zerod pip install -e ".[dev]"
-          strings /usr/share/miniconda/envs/zerod/bin/../lib/libstdc++.so.6 | grep GLIBCXX
       - name: Install Networkx
         run: |
             conda run -n zerod pip install networkx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,7 @@ jobs:
           auto-update-conda: true
       - name: Install ubuntu dependencies
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt update && sudo apt install build-essential cmake lcov
-        run: sudo apt install --only-upgrade libstdc++6
+        run: sudo apt update && sudo apt install build-essential cmake lcov && sudo apt install --only-upgrade libstdc++6
       - name: Install svZeroDSolver
         run: |
           #export PATH="/usr/share/miniconda/bin:$PATH"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Install dependencies to get correct version numbers (MacOS)
         if: startsWith(matrix.os, 'macos')
         run: |
-          brew install gcc@${{ env.GCC_V }}
-          ln -s /usr/local/bin/gcc-${{ env.GCC_V }} /usr/local/bin/gcc
+          brew install gcc@${GCC_V}
+          ln -s /usr/local/bin/gcc-${GCC_V} /usr/local/bin/gcc
       - name: Install svZeroDSolver
         run: conda run -n zerod pip install -e ".[dev]"
       - name: Install Networkx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
         os: [ubuntu-22.04, ubuntu-latest, macos-13, macos-latest]
         version: [13] # GCC version
       fail-fast: false
-      env:
-        GCC_V: ${{ matrix.version }}
+    env:
+      GCC_V: ${{ matrix.version }}
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3

--- a/src/model/Block.h
+++ b/src/model/Block.h
@@ -50,7 +50,7 @@
  * to the global system.
  */
 struct TripletsContributions {
-  TripletsContributions() {};
+  TripletsContributions(){};
   /**
    * @brief Set the number of triplets that the element contributes
    * to the global system.
@@ -58,7 +58,7 @@ struct TripletsContributions {
    * @param E Contributions to E matrix
    * @param D Contributions to dC/dy matrix
    */
-  TripletsContributions(int F, int E, int D) : F(F), E(E), D(D) {};
+  TripletsContributions(int F, int E, int D) : F(F), E(E), D(D){};
   /**
    * @brief Set the number of triplets that the element contributes
    * to the global system.

--- a/src/model/Block.h
+++ b/src/model/Block.h
@@ -50,7 +50,7 @@
  * to the global system.
  */
 struct TripletsContributions {
-  TripletsContributions(){};
+  TripletsContributions() {};
   /**
    * @brief Set the number of triplets that the element contributes
    * to the global system.
@@ -58,7 +58,7 @@ struct TripletsContributions {
    * @param E Contributions to E matrix
    * @param D Contributions to dC/dy matrix
    */
-  TripletsContributions(int F, int E, int D) : F(F), E(E), D(D){};
+  TripletsContributions(int F, int E, int D) : F(F), E(E), D(D) {};
   /**
    * @brief Set the number of triplets that the element contributes
    * to the global system.

--- a/src/solve/SimulationParameters.cpp
+++ b/src/solve/SimulationParameters.cpp
@@ -444,8 +444,8 @@ void create_external_coupling(
           (connected_type == "BloodVessel")) {
         connections.push_back({connected_block, coupling_name});
       }  // connected_type == "ClosedLoopRCR"
-    }    // coupling_loc
-  }      // for (size_t i = 0; i < coupling_configs.length(); i++)
+    }  // coupling_loc
+  }  // for (size_t i = 0; i < coupling_configs.length(); i++)
 }
 
 void create_junctions(


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation
Closes #147


## Release Notes 
Updated dependencies to use GCC 13 on both MacOS and Ubuntu. 

Updated upload-artifact@v3 to upload-artifact@v4

Fixed clang-format to version 19. 

Note that brew installs clang-format version 20 by default on MacOS and I am still seeing some differences in the clang-format output between the Github runner and my local Mac (presumably because of the version 19 on Ubuntu v/s version 20 on Mac, but not sure). It would be great to resolve this but I haven't been able to install clang-format 20 on the Ubuntu runner. An alternative is to make the test fail only if clang-format fails on BOTH Ubuntu and MacOS. That way we will have fewer tests failing just because of differences in the two systems. 


## Documentation
N/A


## Testing
All tests pass. 


## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
