### PR TITLE
Set fixed precision instead of buffer size

### DIFF
--- a/src/solve/csv_writer.cpp
+++ b/src/solve/csv_writer.cpp
@@ -29,6 +29,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "csv_writer.h"
+
 #include <iomanip>
 
 /**
@@ -47,7 +48,7 @@ std::string to_vessel_csv(const std::vector<double> &times,
                           bool mean, bool derivative) {
   // Create string stream to buffer output
   std::stringstream out;
-  
+
   // Set floating point format for the entire stream
   out << std::scientific << std::setprecision(16);
 
@@ -110,27 +111,19 @@ std::string to_vessel_csv(const std::vector<double> &times,
         d_outflow_mean /= num_steps;
         d_inpres_mean /= num_steps;
         d_outpres_mean /= num_steps;
-        
-        out << name << ",," 
-            << inflow_mean << "," 
-            << outflow_mean << "," 
-            << inpres_mean << "," 
-            << outpres_mean << "," 
-            << d_inflow_mean << "," 
-            << d_outflow_mean << "," 
-            << d_inpres_mean << "," 
-            << d_outpres_mean << "\n";
+
+        out << name << ",," << inflow_mean << "," << outflow_mean << ","
+            << inpres_mean << "," << outpres_mean << "," << d_inflow_mean << ","
+            << d_outflow_mean << "," << d_inpres_mean << "," << d_outpres_mean
+            << "\n";
       } else {
         for (size_t i = 0; i < num_steps; i++) {
-          out << name << "," 
-              << times[i] << "," 
-              << states[i].y[inflow_dof] << "," 
-              << states[i].y[outflow_dof] << "," 
-              << states[i].y[inpres_dof] << "," 
-              << states[i].y[outpres_dof] << "," 
-              << states[i].ydot[inflow_dof] << "," 
-              << states[i].ydot[outflow_dof] << "," 
-              << states[i].ydot[inpres_dof] << "," 
+          out << name << "," << times[i] << "," << states[i].y[inflow_dof]
+              << "," << states[i].y[outflow_dof] << ","
+              << states[i].y[inpres_dof] << "," << states[i].y[outpres_dof]
+              << "," << states[i].ydot[inflow_dof] << ","
+              << states[i].ydot[outflow_dof] << ","
+              << states[i].ydot[inpres_dof] << ","
               << states[i].ydot[outpres_dof] << "\n";
         }
       }
@@ -151,20 +144,15 @@ std::string to_vessel_csv(const std::vector<double> &times,
         outflow_mean /= num_steps;
         inpres_mean /= num_steps;
         outpres_mean /= num_steps;
-        
-        out << name << ",," 
-            << inflow_mean << "," 
-            << outflow_mean << "," 
-            << inpres_mean << "," 
-            << outpres_mean << "\n";
+
+        out << name << ",," << inflow_mean << "," << outflow_mean << ","
+            << inpres_mean << "," << outpres_mean << "\n";
       } else {
         for (size_t i = 0; i < num_steps; i++) {
-          out << name << "," 
-              << times[i] << "," 
-              << states[i].y[inflow_dof] << "," 
-              << states[i].y[outflow_dof] << "," 
-              << states[i].y[inpres_dof] << "," 
-              << states[i].y[outpres_dof] << "\n";
+          out << name << "," << times[i] << "," << states[i].y[inflow_dof]
+              << "," << states[i].y[outflow_dof] << ","
+              << states[i].y[inpres_dof] << "," << states[i].y[outpres_dof]
+              << "\n";
         }
       }
     }
@@ -189,7 +177,7 @@ std::string to_variable_csv(const std::vector<double> &times,
                             const Model &model, bool mean, bool derivative) {
   // Create string stream to buffer output
   std::stringstream out;
-  
+
   // Set floating point format for the entire stream
   out << std::scientific << std::setprecision(16);
 
@@ -211,18 +199,14 @@ std::string to_variable_csv(const std::vector<double> &times,
         }
         mean_y /= num_steps;
         mean_ydot /= num_steps;
-        
-        out << name << ",," 
-            << mean_y << "," 
-            << mean_ydot << "\n";
+
+        out << name << ",," << mean_y << "," << mean_ydot << "\n";
       }
     } else {
       for (size_t i = 0; i < model.dofhandler.size(); i++) {
         std::string name = model.dofhandler.variables[i];
         for (size_t j = 0; j < num_steps; j++) {
-          out << name << "," 
-              << times[j] << "," 
-              << states[j].y[i] << "," 
+          out << name << "," << times[j] << "," << states[j].y[i] << ","
               << states[j].ydot[i] << "\n";
         }
       }
@@ -237,17 +221,14 @@ std::string to_variable_csv(const std::vector<double> &times,
           mean_y += states[j].y[i];
         }
         mean_y /= num_steps;
-        
-        out << name << ",," 
-            << mean_y << "\n";
+
+        out << name << ",," << mean_y << "\n";
       }
     } else {
       for (size_t i = 0; i < model.dofhandler.size(); i++) {
         std::string name = model.dofhandler.variables[i];
         for (size_t j = 0; j < num_steps; j++) {
-          out << name << "," 
-              << times[j] << "," 
-              << states[j].y[i] << "\n";
+          out << name << "," << times[j] << "," << states[j].y[i] << "\n";
         }
       }
     }

--- a/src/solve/csv_writer.cpp
+++ b/src/solve/csv_writer.cpp
@@ -29,6 +29,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "csv_writer.h"
+#include <iomanip>
 
 /**
  * @brief Write results vessel based.
@@ -46,10 +47,9 @@ std::string to_vessel_csv(const std::vector<double> &times,
                           bool mean, bool derivative) {
   // Create string stream to buffer output
   std::stringstream out;
-
-  // Create short and long buffer for lines
-  char sbuff[140];
-  char lbuff[236];
+  
+  // Set floating point format for the entire stream
+  out << std::scientific << std::setprecision(16);
 
   // Write column labels
   if (derivative) {
@@ -110,21 +110,28 @@ std::string to_vessel_csv(const std::vector<double> &times,
         d_outflow_mean /= num_steps;
         d_inpres_mean /= num_steps;
         d_outpres_mean /= num_steps;
-        snprintf(
-            lbuff, 236, "%s,,%.16e,%.16e,%.16e,%.16e,%.16e,%.16e,%.16e,%.16e\n",
-            name.c_str(), inflow_mean, outflow_mean, inpres_mean, outpres_mean,
-            d_inflow_mean, d_outflow_mean, d_inpres_mean, d_outpres_mean);
-        out << lbuff;
+        
+        out << name << ",," 
+            << inflow_mean << "," 
+            << outflow_mean << "," 
+            << inpres_mean << "," 
+            << outpres_mean << "," 
+            << d_inflow_mean << "," 
+            << d_outflow_mean << "," 
+            << d_inpres_mean << "," 
+            << d_outpres_mean << "\n";
       } else {
         for (size_t i = 0; i < num_steps; i++) {
-          snprintf(lbuff, 236,
-                   "%s,%.16e,%.16e,%.16e,%.16e,%.16e,%.16e,%.16e,%.16e,%.16e\n",
-                   name.c_str(), times[i], states[i].y[inflow_dof],
-                   states[i].y[outflow_dof], states[i].y[inpres_dof],
-                   states[i].y[outpres_dof], states[i].ydot[inflow_dof],
-                   states[i].ydot[outflow_dof], states[i].ydot[inpres_dof],
-                   states[i].ydot[outpres_dof]);
-          out << lbuff;
+          out << name << "," 
+              << times[i] << "," 
+              << states[i].y[inflow_dof] << "," 
+              << states[i].y[outflow_dof] << "," 
+              << states[i].y[inpres_dof] << "," 
+              << states[i].y[outpres_dof] << "," 
+              << states[i].ydot[inflow_dof] << "," 
+              << states[i].ydot[outflow_dof] << "," 
+              << states[i].ydot[inpres_dof] << "," 
+              << states[i].ydot[outpres_dof] << "\n";
         }
       }
     } else {
@@ -144,16 +151,20 @@ std::string to_vessel_csv(const std::vector<double> &times,
         outflow_mean /= num_steps;
         inpres_mean /= num_steps;
         outpres_mean /= num_steps;
-        snprintf(sbuff, 140, "%s,,%.16e,%.16e,%.16e,%.16e\n", name.c_str(),
-                 inflow_mean, outflow_mean, inpres_mean, outpres_mean);
-        out << sbuff;
+        
+        out << name << ",," 
+            << inflow_mean << "," 
+            << outflow_mean << "," 
+            << inpres_mean << "," 
+            << outpres_mean << "\n";
       } else {
         for (size_t i = 0; i < num_steps; i++) {
-          snprintf(sbuff, 140, "%s,%.16e,%.16e,%.16e,%.16e,%.16e\n",
-                   name.c_str(), times[i], states[i].y[inflow_dof],
-                   states[i].y[outflow_dof], states[i].y[inpres_dof],
-                   states[i].y[outpres_dof]);
-          out << sbuff;
+          out << name << "," 
+              << times[i] << "," 
+              << states[i].y[inflow_dof] << "," 
+              << states[i].y[outflow_dof] << "," 
+              << states[i].y[inpres_dof] << "," 
+              << states[i].y[outpres_dof] << "\n";
         }
       }
     }
@@ -178,10 +189,9 @@ std::string to_variable_csv(const std::vector<double> &times,
                             const Model &model, bool mean, bool derivative) {
   // Create string stream to buffer output
   std::stringstream out;
-
-  // Create short and long buffer for lines
-  char sbuff[87];
-  char lbuff[110];
+  
+  // Set floating point format for the entire stream
+  out << std::scientific << std::setprecision(16);
 
   // Determine number of time steps
   int num_steps = times.size();
@@ -201,17 +211,19 @@ std::string to_variable_csv(const std::vector<double> &times,
         }
         mean_y /= num_steps;
         mean_ydot /= num_steps;
-        snprintf(lbuff, 110, "%s,,%.16e,%.16e\n", name.c_str(), mean_y,
-                 mean_ydot);
-        out << lbuff;
+        
+        out << name << ",," 
+            << mean_y << "," 
+            << mean_ydot << "\n";
       }
     } else {
       for (size_t i = 0; i < model.dofhandler.size(); i++) {
         std::string name = model.dofhandler.variables[i];
         for (size_t j = 0; j < num_steps; j++) {
-          snprintf(lbuff, 110, "%s,%.16e,%.16e,%.16e\n", name.c_str(), times[j],
-                   states[j].y[i], states[j].ydot[i]);
-          out << lbuff;
+          out << name << "," 
+              << times[j] << "," 
+              << states[j].y[i] << "," 
+              << states[j].ydot[i] << "\n";
         }
       }
     }
@@ -225,16 +237,17 @@ std::string to_variable_csv(const std::vector<double> &times,
           mean_y += states[j].y[i];
         }
         mean_y /= num_steps;
-        snprintf(sbuff, 87, "%s,,%.16e\n", name.c_str(), mean_y);
-        out << sbuff;
+        
+        out << name << ",," 
+            << mean_y << "\n";
       }
     } else {
       for (size_t i = 0; i < model.dofhandler.size(); i++) {
         std::string name = model.dofhandler.variables[i];
         for (size_t j = 0; j < num_steps; j++) {
-          snprintf(sbuff, 87, "%s,%.16e,%.16e\n", name.c_str(), times[j],
-                   states[j].y[i]);
-          out << sbuff;
+          out << name << "," 
+              << times[j] << "," 
+              << states[j].y[i] << "\n";
         }
       }
     }


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation
Closes #100

## Release Notes 
Set a fixed precision for scientific notation output instead of a fixed-sized buffer

## Documentation
No change in functionality

## Testing
Similar performance in test cases and works with large variable names

## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
