### PR TITLE
Error output time step for testing

### DIFF
--- a/src/algebra/Integrator.cpp
+++ b/src/algebra/Integrator.cpp
@@ -83,7 +83,8 @@ State Integrator::step(const State& old_state, double time) {
     // Abort if maximum number of non-linear iterations is reached
     else if (i == max_iter - 1) {
       throw std::runtime_error(
-          "Maximum number of non-linear iterations reached.");
+          "Maximum number of non-linear iterations reached at time " +
+          std::to_string(time));
     }
 
     // Evaluate Jacobian


### PR DESCRIPTION
Error output time step for testing

## Current situation
When running a test case there is currently no way to know until which time step the code runs before throwing the following error: "terminating due to uncaught exception of type std::runtime_error: Maximum number of non-linear iterations reached."


## Release Notes 
Added the output of the last time step to the error message


## Code of Conduct & Contributing Guidelines 
- [ ] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).