### PR TITLE
Update deprecated function/argument names for svZeroDVisualization

### DIFF
--- a/applications/svZeroDVisualization/visualize_simulation.py
+++ b/applications/svZeroDVisualization/visualize_simulation.py
@@ -388,9 +388,11 @@ app.layout = html.Div([
         figure={
             'data': [edge_trace, vessel_trace, chamber_trace, valve_trace, junction_trace, bc_trace],
             'layout': go.Layout(
-                title='Network Graph',
-                titlefont_size=30,
-                title_x=0.5,
+                title={
+                    'text': 'Network Graph',
+                    'x': 0.5,
+                    'font': {'size': 30}
+                },
                 showlegend=True,
                 hovermode='closest',
                 margin=dict(b=20, l=0, r=0, t=50),
@@ -469,9 +471,11 @@ def update_graphs(clickData):
     fig = go.Figure(
         data=[edge_trace, vessel_trace, chamber_trace, valve_trace, junction_trace, bc_trace],
         layout=go.Layout(
-            title='Network Graph',
-            titlefont_size=30,
-            title_x=0.5,
+            title={
+                'text': 'Network Graph',
+                'x': 0.5,
+                'font': {'size': 30}
+            },
             showlegend=True,
             hovermode='closest',
             margin=dict(b=20, l=0, r=0, t=50),
@@ -651,4 +655,4 @@ def update_graphs(clickData):
 
 
 if __name__ == '__main__':
-    app.run_server(debug=True)
+    app.run(debug=True)


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation
Running the svZeroDVisualization app (specifically `visualize_simulation.py`) encountered errors related to invalid names of functions/arguments for certain Python libraries. Probably these libraries were updated and no longer support certain function/argument names.


## Release Notes 
- Minor changes plotly.graph_objects plotting function and Dash app run command


## Testing
Tested locally on my Macbook with freshly installed Python libraries and works.


## Code of Conduct & Contributing Guidelines 
- [ ] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
