### PR TITLE
Check license header

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,14 @@
+# This workflow checks that all .h/.cpp files have the SPDX copyright header at the top
+name: Copyright
+on: [push, pull_request]
+jobs:
+  check-license-lines:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Deno
+      uses: denoland/setup-deno@v1
+      with:
+        deno-version: v1.x
+    - name: Check License
+      run: deno run --allow-read jsr:@kt3k/license-checker@3.3.1

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,14 +1,7 @@
 {
-  "**/*.{h,hpp,c,cpp}": [
+  "src/*.{h,hpp,c,cpp}": [
     "SPDX-FileCopyrightText: Copyright (c) Stanford University, The Regents of the University of California, and others.",
     "SPDX-License-Identifier: BSD-3-Clause"
   ],
-  "ignore": [
-    "Distribution",
-    "Documentation",
-    "Externals",
-    "Licenses",
-    "Code/ThirdParty",
-    "Code/Source/svFSILS/back"
-  ]
+  "ignore": []
 }

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,0 +1,14 @@
+{
+  "**/*.{h,hpp,c,cpp}": [
+    "SPDX-FileCopyrightText: Copyright (c) Stanford University, The Regents of the University of California, and others.",
+    "SPDX-License-Identifier: BSD-3-Clause"
+  ],
+  "ignore": [
+    "Distribution",
+    "Documentation",
+    "Externals",
+    "Licenses",
+    "Code/ThirdParty",
+    "Code/Source/svFSILS/back"
+  ]
+}


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation
We changed the format of our license (#178), but we are not checking if the license is actually present in our source code. It's annoying to manually check if the license is present and tell people to change it.

## Release Notes 
I copied the simple workflow to check the license header from svMultiPhysics.

## Documentation
Nope

## Testing
Let's see if the workflow runs.


## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
